### PR TITLE
add feature flags

### DIFF
--- a/src/handlers/loaders/buttons.js
+++ b/src/handlers/loaders/buttons.js
@@ -1,5 +1,12 @@
 const fs = require(`fs`);
 
+const featureFlags = {
+	"acceptTermsButton.js": true,
+	"approveButton.js": true,
+	"openTicket.js": true,
+	"startFormButton.js": true,
+}
+
 class ButtonsHandler {
 	/**
 	 * @param {import("discord.js").Client} client
@@ -15,6 +22,13 @@ class ButtonsHandler {
 			.filter((files) => files.endsWith(`.js`));
 		if (button_files) {
 			for (const file of button_files) {
+				if (file in featureFlags && featureFlags[file] === false) {
+					// Skip loading this button
+					continue;
+				}
+				if (!(file in featureFlags)) {
+					console.log(`Button ${file} not in featureFlags, please add it to the list.`);
+				}
 				const path_final = `${process.cwd()}/${buttons_path}/${file}`;
 				const button = require(path_final);
 				if (!button.customId) continue;

--- a/src/handlers/loaders/commands.js
+++ b/src/handlers/loaders/commands.js
@@ -35,7 +35,7 @@ class CommandHandler {
 					// Skip loading this command
 					continue;
 				}
-				if (!(folder in featureFlags)) {
+				if (!(folder in featureFlags) && !folder.endsWith(`.js`)) {
 					console.log(`Command ${folder} not in featureFlags, please add it to the list.`);
 				}
 				const path_final = `${process.cwd()}/${commands_path}/${dirs}/${folder}`;

--- a/src/handlers/loaders/commands.js
+++ b/src/handlers/loaders/commands.js
@@ -1,6 +1,19 @@
 const { REST, Routes } = require(`discord.js`);
 const fs = require(`fs`);
 
+const featureFlags = {
+	"admin": true,
+	"badges": true,
+	"boost": true,
+	"flag": true,
+	"info": true,
+	"ping": true,
+	"profile": true,
+	"ranking": true,
+	"ticket": true,
+	"tutoria": true,
+}
+
 class CommandHandler {
 	/**
 	 * @param {import("discord.js").Client} client
@@ -18,6 +31,13 @@ class CommandHandler {
 				.filter((files) => files.endsWith(`.js`));
 
 			for (const folder of commandFolders) {
+				if (folder in featureFlags && featureFlags[folder] === false) {
+					// Skip loading this command
+					continue;
+				}
+				if (!(folder in featureFlags)) {
+					console.log(`Command ${folder} not in featureFlags, please add it to the list.`);
+				}
 				const path_final = `${process.cwd()}/${commands_path}/${dirs}/${folder}`;
 				const command = require(path_final);
 				if (!command.data) continue;

--- a/src/handlers/loaders/events.js
+++ b/src/handlers/loaders/events.js
@@ -1,6 +1,24 @@
 const { Events } = require(`discord.js`);
 const fs = require(`fs`);
 
+const featureFlags = {
+	"client/clientReady.js": true,
+	"client/interactionCreate.js": true,
+	"client/tickEvent.js": true, 
+	"custom/buttonExec.js": true, 
+	"custom/commandExec.js": true, 
+	"custom/errorApi.js": true, 
+	"custom/errorCreate.js": true, 
+	"message/messageCreate.js": true, 
+	"message/messageDelete.js": true, 
+	"message/messageUpdate.js": true, 
+	"server/guildBanAdd.js": true, 
+	"server/guildBanRemove.js": true, 
+	"server/guildMemberAdd.js": true, 
+	"server/guildMemberRemove.js": true, 
+	"server/voiceStateUpdate.js": true,
+}
+
 class EventHandler {
 	constructor(client) {
 		this.client = client;
@@ -13,6 +31,15 @@ class EventHandler {
 				.filter((files) => files.endsWith(`.js`));
 
 			for (const file of events) {
+				const eventFinal = `${dirs}/${file}`
+				if (eventFinal in featureFlags && featureFlags[eventFinal] === false) {
+					// Skip loading this event
+					continue;
+				}
+				if (!(eventFinal in featureFlags)) {
+					console.log(`Event ${eventFinal} not in featureFlags, please add it to the list.`);
+				}
+
 				const event = require(`../../events/${dirs}/${file}`);
 				const eventName = file.split(`.`)[0];
 				const eventUpperCase =


### PR DESCRIPTION
Added in each loader file an object with keys as the loaded paths paired with a boolean. If the boolean is false, the file key won't be loaded. This can be used to turn features on or off with ease.

A form of expanding this would be to make it so the flags can be changed at runtime, and the bot will reregister itself accordingly.

https://www.alura.com.br/artigos/o-que-sao-feature-flags-feature-toggles